### PR TITLE
connectClient test

### DIFF
--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -11,7 +11,7 @@ export const chainIdToInfo: {
 }
 
 export const interfaceIds = {
-  ISoundEditionV1: '0x3b8ebf6f',
+  ISoundEditionV1: '0x41f5b0cb',
   IMinterModule: '0x41af72ad',
   IFixedPriceSignatureMinter: '0xc7843744',
   IMerkleDropMinter: '0x7deee220',

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,7 +23,6 @@ const SUPPORTED_CHAIN_IDS = [
 
 type ChainId = typeof SUPPORTED_CHAIN_IDS[number]
 
-// TODO: add tests for this
 export function createClient(signerOrProvider: Signer | Provider) {
   if (!signerOrProvider) {
     throw new Error('Must provide signer or provider')
@@ -84,10 +83,22 @@ export async function mint(client: SoundClient, params: { address: string }) {
   HELPER FUNCTIONS
  ******************/
 
-// TODO: add tests for this
-async function connectClient(client: SoundClient) {
-  const network = await client.provider?.getNetwork()
-  const chainId = network?.chainId || (await client.signer?.getChainId())
+export async function connectClient(client: SoundClient) {
+  let chainId: number | undefined
+  if (client.signer) {
+    try {
+      chainId = await client.signer.getChainId()
+    } catch (e: any) {
+      if (e?.message.includes('missing provider')) {
+        throw new Error('Signer must be connected to a provider: https://docs.ethers.io/v5/api/signer/#Signer-connect')
+      } else {
+        throw e
+      }
+    }
+  } else {
+    const network = await client.provider!.getNetwork()
+    chainId = network.chainId
+  }
 
   // Using type cast for chainId here because we know signer or provider exists,
   // therefore chainId will be defined.

--- a/packages/sdk/test/index.test.ts
+++ b/packages/sdk/test/index.test.ts
@@ -1,10 +1,12 @@
 import 'dotenv/config'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { createClient, SoundClient, isSoundEdition } from '../src/index'
+import { createClient, connectClient, SoundClient, isSoundEdition } from '../src/index'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { parseEther } from '@ethersproject/units'
 import { Wallet } from '@ethersproject/wallet'
 
+// First private key from 'test test test...' mnemonic
+const TEST_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
 const PROVIDER_URL = 'http://localhost:8545'
 
 const provider = new JsonRpcProvider({ url: PROVIDER_URL })
@@ -35,6 +37,17 @@ describe('createClient', () => {
     expect(client.signer).toBeNull()
     expect(client.provider).toBeDefined()
     expect(client.connect).toBeDefined()
+  })
+})
+
+describe('connectClient', () => {
+  it('Should throw error if the signer is not connected to a provider', async () => {
+    const signer = new Wallet(TEST_PK)
+    const client = createClient(signer)
+
+    await expect(() => connectClient(client)).rejects.toThrowError(
+      'Signer must be connected to a provider: https://docs.ethers.io/v5/api/signer/#Signer-connect',
+    )
   })
 })
 


### PR DESCRIPTION
If user only provides a signer, it must be connected to a network to be usable. The reason we allow a provider _or_ signer is a provider is only needed for any integration that isn't using `mint` (ie: read-only) while a signer is needed to call `mint`, but we need to check its connected to a network.