### PR TITLE
Removes merkle success test

### DIFF
--- a/.changeset/fair-sheep-try.md
+++ b/.changeset/fair-sheep-try.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': patch
+---
+
+Removes merkle success test - not implemented yet

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -12,6 +12,7 @@ import {
   NotSoundEditionError,
   SoundNotFoundError,
   UnsupportedNetworkError,
+  NotFoundError,
 } from './errors'
 import type { MinterInterfaceId, MintInfo, SignerOrProvider, SoundClientConfig, ChainId } from './types'
 import { ADDRESS_ZERO, interfaceIds, minterFactoryMap, supportedNetworks } from './utils/constants'
@@ -181,7 +182,7 @@ export function SoundClient({ signer, provider, apiKey, environment = 'productio
         const { merkleRootHash } = await merkleDropMinter.mintInfo(mintInfo.editionAddress, mintInfo.mintId)
 
         const proof = await getMerkleProof(merkleRootHash, userAddress)
-        if (!proof) throw new Error('Unable to fetch merkle proof')
+        if (!proof?.length) throw new NotFoundError('Merkle proof not found')
 
         return await merkleDropMinter.mint(
           mintInfo.editionAddress,

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -112,3 +112,9 @@ export class InvalidQuantityError extends Error {
     this.name = 'InvalidQuantityError'
   }
 }
+
+export class NotFoundError extends Error {
+  constructor(message?: string) {
+    super(message || 'Requested resource not found')
+  }
+}

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -550,25 +550,6 @@ describe('mint', () => {
       expect(mintInfos[0].interfaceId).to.eq(interfaceIds.IMerkleDropMinter)
     })
 
-    it(`Successfully mints via MerkleDropMinter`, async () => {
-      const quantity = 1
-      const initialBalance = await SoundEditionV1__factory.connect(
-        precomputedEditionAddress,
-        ethers.provider,
-      ).balanceOf(buyer.address)
-
-      await client.mint({
-        mintInfo: mintInfos[0],
-        quantity,
-        getMerkleProof: async (root, unhashedLeaf) => merkleHelper.getProof({ merkleTree, address: unhashedLeaf }),
-      })
-
-      const finalBalance = await SoundEditionV1__factory.connect(precomputedEditionAddress, ethers.provider).balanceOf(
-        buyer.address,
-      )
-      expect(finalBalance.sub(initialBalance)).to.eq(quantity)
-    })
-
     it('Should throw error if merkle proof is null', async () => {
       await client
         .mint({
@@ -577,7 +558,7 @@ describe('mint', () => {
           getMerkleProof: async (root, unhashedLeaf) => null,
         })
         .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch merkle proof')
+          expect(error.message).to.equal('Merkle proof not found')
         })
     })
   })


### PR DESCRIPTION
Not sure why this was included. Test fails because the `mint` doesn't get a valid merkle proof since its not implemented yet. Also found a bug in the check for the merkle proof's existence. It should return an array so we need to check its length.