### PR TITLE
Adds maxMintable to editionInfo response

### DIFF
--- a/.changeset/stupid-lamps-burn.md
+++ b/.changeset/stupid-lamps-burn.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': minor
+---
+
+Adds maxMintable to editionInfo response

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -395,9 +395,10 @@ export function SoundClient({
       (await _requireSignerOrProvider()).signerOrProvider,
     )
 
-    const [{ data, errors }, totalMintedBigNum] = await Promise.all([
+    const [{ data, errors }, totalMintedBigNum, maxMintable] = await Promise.all([
       client.soundApi.releaseInfo(soundParams),
       editionContract.totalMinted(),
+      editionContract.editionMaxMintable(),
     ])
 
     const release = data?.release
@@ -405,8 +406,9 @@ export function SoundClient({
 
     return {
       ...release,
-      totalMinted: totalMintedBigNum.toNumber(),
       trackAudio: LazyPromise(() => client.soundApi.audioFromTrack({ trackId: release.track.id })),
+      totalMinted: totalMintedBigNum.toNumber(),
+      maxMintable,
     }
   }
 


### PR DESCRIPTION
We should have tests for this but we don't have one at all for `editionInfo` yet and Bonfire is already using. Made a ticket:

https://linear.app/sound/issue/INFRA-848/improve-sdk-tests