### PR TITLE
Bug fix: Converts salt to string

### DIFF
--- a/.changeset/lazy-otters-remain.md
+++ b/.changeset/lazy-otters-remain.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': patch
+---
+
+Convert salt to string before converting to bytes32

--- a/packages/sdk/src/utils/helpers.ts
+++ b/packages/sdk/src/utils/helpers.ts
@@ -9,5 +9,5 @@ export function validateAddress(contractAddress: string) {
 }
 
 export function getSaltAsBytes32(salt: string | number) {
-  return '0x' + keccak256(salt).toString('hex')
+  return '0x' + keccak256(salt.toString()).toString('hex')
 }

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -752,15 +752,24 @@ describe('expectedEditionAddress', () => {
 
   it('returns expected address', async () => {
     const deployer = artistWallet.address
-    const salt = '12345'
+    const salt1 = Math.random()
+    const salt2 = Math.random()
 
-    const expectedAddress = await SoundCreatorV1__factory.connect(
+    const expectedAddress1 = await SoundCreatorV1__factory.connect(
       soundCreator.address,
       ethers.provider,
-    ).soundEditionAddress(deployer, getSaltAsBytes32(salt))
+    ).soundEditionAddress(deployer, getSaltAsBytes32(salt1))
 
-    const address = await client.expectedEditionAddress({ deployer, salt })
+    const expectedAddress2 = await SoundCreatorV1__factory.connect(
+      soundCreator.address,
+      ethers.provider,
+    ).soundEditionAddress(deployer, getSaltAsBytes32(salt2))
 
-    expect(address).to.eq(expectedAddress)
+    const address1 = await client.expectedEditionAddress({ deployer, salt: salt1 })
+    const address2 = await client.expectedEditionAddress({ deployer, salt: salt2 })
+
+    expect(address1).to.eq(expectedAddress1)
+    expect(address2).to.eq(expectedAddress2)
+    expect(address1).not.to.eq(address2)
   })
 })


### PR DESCRIPTION
While trying to deploy a test edition for Bonfire, I realized that passing Math.random() results in the same address each time. Converting to string prior to converting to bytes solved it. Improved the tests to cover it.