### PR TITLE
explicit overrides types

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -26,7 +26,7 @@ import { LazyPromise } from './utils/promise'
 import type { ChainId, MinterInterfaceId, SignerOrProvider, SoundClientConfig } from './types'
 import type { Signer } from '@ethersproject/abstract-signer'
 import type { BigNumberish } from '@ethersproject/bignumber'
-import type { ContractTransaction } from '@ethersproject/contracts'
+import type { ContractTransaction, Overrides, PayableOverrides } from '@ethersproject/contracts'
 import type { ReleaseInfoQueryVariables } from './api/graphql/gql'
 import type { ContractCall, EditionConfig, MintConfig, MintSchedule } from './types'
 
@@ -206,7 +206,7 @@ export function SoundClient({
       })
     }
 
-    const txnOverrides = {
+    const txnOverrides: PayableOverrides = {
       value: mintSchedule.price.mul(quantity),
       gasLimit,
       maxFeePerGas,
@@ -270,7 +270,7 @@ export function SoundClient({
   }) {
     const { signer, chainId, userAddress } = await _requireSigner()
 
-    const txnOverrides = {
+    const txnOverrides: Overrides = {
       gasLimit,
       maxFeePerGas,
       maxPriorityFeePerGas,


### PR DESCRIPTION
never create an object without pre-defined types when creating libraries/shared code, it allows you to put incorrect fields and nothing will notify you, because typescript by default it very permissive when giving broad objects into function parameters, which a lot of the time is good for the end user, but in this kind of cases like libraries, not really.

example:
![image](https://user-images.githubusercontent.com/8672915/190840515-f6ff5b3c-da18-4d16-b38e-faf6b20e6d15.png)
![image](https://user-images.githubusercontent.com/8672915/190840528-a27bf888-ce25-4565-89bb-47196a5bceb3.png)
