### PR TITLE
merkleProof -> merkleProofGetter

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -44,7 +44,7 @@ export function SoundClient({
   apiEndpoint,
   soundCreatorAddress,
   onError = console.error,
-  merkleProof,
+  merkleProofGetter,
 }: SoundClientConfig) {
   const client = {
     soundApi: SoundAPI({
@@ -179,7 +179,7 @@ export function SoundClient({
     gasLimit,
     maxFeePerGas,
     maxPriorityFeePerGas,
-    merkleProof: merkleProofArg,
+    merkleProofGetter: mintMerkleProofGetter,
   }: MintOptions): Promise<ContractTransaction> {
     await _requireValidSoundEdition({ editionAddress: mintSchedule.editionAddress })
     if (quantity <= 0 || Math.floor(quantity) !== quantity) throw new InvalidQuantityError({ quantity })
@@ -217,7 +217,10 @@ export function SoundClient({
         const merkleDropMinter = MerkleDropMinter__factory.connect(mintSchedule.minterAddress, signer)
         const { merkleRootHash } = await merkleDropMinter.mintInfo(mintSchedule.editionAddress, mintSchedule.mintId)
 
-        const proof = await (merkleProofArg || merkleProof || getMerkleProof)({ merkleRootHash, userAddress })
+        const proof = await (mintMerkleProofGetter || merkleProofGetter || getMerkleProof)({
+          merkleRootHash,
+          userAddress,
+        })
 
         if (!proof?.length) {
           throw new NotEligibleMint({

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -55,7 +55,7 @@ export interface MintOptions {
    *
    * @default SoundAPI.merkleProof
    */
-  merkleProof?: MerkleProofGetter
+  merkleProofGetter?: MerkleProofGetter
 }
 
 export interface BaseSoundClientConfig {
@@ -70,7 +70,7 @@ export interface BaseSoundClientConfig {
    *
    * @default SoundAPI.merkleProof
    */
-  merkleProof?: MerkleProofGetter
+  merkleProofGetter?: MerkleProofGetter
 }
 
 export type SoundClientConfig = (

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -628,7 +628,7 @@ describe('mint', () => {
       await client.mint({
         mintSchedule: mintSchedules[0],
         quantity,
-        merkleProof({ userAddress }) {
+        merkleProofGetter({ userAddress }) {
           return merkleTestHelper.getProof({ merkleTree, address: userAddress })
         },
       })
@@ -645,7 +645,7 @@ describe('mint', () => {
         .mint({
           mintSchedule: mintSchedules[0],
           quantity: 1,
-          merkleProof({ userAddress }) {
+          merkleProofGetter({ userAddress }) {
             return merkleTestHelper.getProof({ merkleTree, address: userAddress })
           },
         })


### PR DESCRIPTION
@PabloSzx Sorry I should have requested this earlier. I know typescript can explain what's going on, but "merkle proof" always means a list of hashes, so I think we need to be more specific with the function name to reduce confusion long term.