### PR TITLE
Removes pointless test

### DIFF
--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -1286,22 +1286,6 @@ describe('expectedEditionAddress', () => {
       })
   })
 
-  it('throws if provider not connected', async () => {
-    client = SoundClient({
-      provider: new ethers.providers.JsonRpcProvider(),
-      soundCreatorAddress: soundCreator.address,
-    })
-
-    await client
-      .expectedEditionAddress({ deployer: '0xbf9a1fad0cbd61cc8158ccb6e1e8e111707088bb', salt: '123' })
-      .then(() => {
-        throw Error(`Didn't throw expected error`)
-      })
-      .catch((error) => {
-        expect(error.message).includes('could not detect network')
-      })
-  })
-
   it('returns expected address', async () => {
     const deployer = artistWallet.address
     const salt1 = Math.random()


### PR DESCRIPTION
This test breaks if you have hardhat running in any terminal locally (the JsonRpcProvider must use localhost:8545 by default), but it's also kind of pointless since its testing the ethers.js error that gets thrown if there is no connected network. We should only be testing our own code.