### PR TITLE
"eligibleQuantity" should never return negative

### DIFF
--- a/.changeset/chatty-mice-compete.md
+++ b/.changeset/chatty-mice-compete.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': patch
+---
+
+"eligibleQuantity" should never return less than 0

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -227,7 +227,7 @@ export function SoundClient({
         : mintSchedule.maxMintable) - mintSchedule.totalMinted
 
     const alreadyMinted = await numberMinted({ editionAddress: mintSchedule.editionAddress, userAddress })
-    return Math.min(remaining, mintSchedule.maxMintablePerAccount - alreadyMinted)
+    return Math.max(Math.min(remaining, mintSchedule.maxMintablePerAccount - alreadyMinted), 0)
   }
 
   function getMerkleProof({ merkleRoot, userAddress }: MerkleProofParameters) {


### PR DESCRIPTION
This is due to maxMintsPerWallet changing on the schedules and if you buy 50 on the first schedule, and the second schedule has maxMints of 25, it would return `eligibleQuantity: -25 `