### PR TITLE
Adds EditionMaxMinter 

### DIFF
--- a/.changeset/heavy-hairs-invite.md
+++ b/.changeset/heavy-hairs-invite.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': minor
+---
+
+Adds EditionMaxMinter

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -58,8 +58,6 @@ import type { ReleaseInfoQueryVariables } from './api/graphql/gql'
 import type { ContractCall, EditionConfig, MintConfig, MintSchedule } from './types'
 import type { EditionInfoStructOutput } from '@soundxyz/sound-protocol/typechain/ISoundEditionV1_1'
 
-/* eslint no-fallthrough: ["error", { "allowEmptyCase": true }] */
-
 export function SoundClient({
   signer,
   provider,
@@ -942,8 +940,7 @@ export function SoundClient({
 
   function _validateMintConfigs(mintConfigs: MintConfig[]) {
     for (const mintConfig of mintConfigs) {
-<<<<<<< HEAD
-      const { maxMintablePerAccount, minterAddress } = mintConfig
+      const { startTime, endTime, maxMintablePerAccount, minterAddress } = mintConfig
 
       validateAddress({
         type: 'MINTER',
@@ -951,9 +948,6 @@ export function SoundClient({
         notNull: true,
       })
 
-=======
-      const { startTime, endTime, maxMintablePerAccount } = mintConfig
->>>>>>> changeset
       if (maxMintablePerAccount < 1) {
         throw new InvalidMaxMintablePerAccountError({ maxMintablePerAccount })
       }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -299,11 +299,13 @@ export class InvalidTimeValuesError extends Error {
   readonly name = 'InvalidTimeValuesError'
 
   readonly startTime: number
-  readonly cutoffTime: number
+  readonly cutoffTime?: number
   readonly endTime: number
 
-  constructor({ startTime, cutoffTime, endTime }: { startTime: number; cutoffTime: number; endTime: number }) {
-    super('startTime must be earlier than cutoffTime and cutoffTime must be earlier than endTime')
+  constructor({ startTime, cutoffTime, endTime }: { startTime: number; cutoffTime?: number; endTime: number }) {
+    super(
+      `startTime must be earlier than ${cutoffTime ? 'cutoffTime and cutoffTime must be earlier than ' : ''}endTime`,
+    )
 
     this.startTime = startTime
     this.cutoffTime = cutoffTime

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -82,6 +82,11 @@ export type SoundClientConfig = (
 ) &
   BaseSoundClientConfig
 
+export type MinterInterfaceId =
+  | typeof interfaceIds.IMerkleDropMinter
+  | typeof interfaceIds.IRangeEditionMinter
+  | typeof interfaceIds.IEditionMaxMinter
+
 export type MintScheduleBase = {
   editionAddress: string
   minterAddress: string
@@ -91,16 +96,14 @@ export type MintScheduleBase = {
   mintPaused: boolean
   price: BigNumber
   maxMintablePerAccount: number
-  totalMinted: number
 }
-
-export type MinterInterfaceId = typeof interfaceIds.IMerkleDropMinter | typeof interfaceIds.IRangeEditionMinter
 
 export type RangeEditionSchedule = MintScheduleBase & {
   mintType: 'RangeEdition'
   maxMintableLower: number
   maxMintableUpper: number
   cutoffTime: number
+  totalMinted: number
   maxMintable: (unixTimestamp?: number) => number
 }
 
@@ -108,9 +111,15 @@ export type MerkleDropSchedule = MintScheduleBase & {
   mintType: 'MerkleDrop'
   maxMintable: number
   merkleRoot: string
+  totalMinted: number
 }
 
-export type MintSchedule = RangeEditionSchedule | MerkleDropSchedule
+export type EditionMaxSchedule = MintScheduleBase & {
+  mintType: 'EditionMax'
+  maxMintable: (unixTimestamp?: number) => number
+}
+
+export type MintSchedule = RangeEditionSchedule | MerkleDropSchedule | EditionMaxSchedule
 
 export function isRangeEditionSchedule(schedule: MintSchedule): schedule is RangeEditionSchedule {
   return schedule.mintType === 'RangeEdition'
@@ -118,6 +127,10 @@ export function isRangeEditionSchedule(schedule: MintSchedule): schedule is Rang
 
 export function isMerkleDropSchedule(schedule: MintSchedule): schedule is MerkleDropSchedule {
   return schedule.mintType === 'MerkleDrop'
+}
+
+export function isEditionMaxSchedule(schedule: MintSchedule): schedule is EditionMaxSchedule {
+  return schedule.mintType === 'EditionMax'
 }
 
 /**
@@ -148,6 +161,7 @@ export type MintConfigBase = {
   startTime: number
   endTime: number
   affiliateFeeBPS: number
+  maxMintablePerAccount: number
 }
 
 /**
@@ -157,7 +171,6 @@ export type MerkleDropConfig = MintConfigBase & {
   mintType: 'MerkleDrop'
   merkleRoot: string
   maxMintable: number
-  maxMintablePerAccount: number
 }
 
 export type RangeEditionConfig = MintConfigBase & {
@@ -165,10 +178,13 @@ export type RangeEditionConfig = MintConfigBase & {
   cutoffTime: number
   maxMintableLower: number
   maxMintableUpper: number
-  maxMintablePerAccount: number
 }
 
-export type MintConfig = MerkleDropConfig | RangeEditionConfig
+export type EditionMaxMinterConfig = MintConfigBase & {
+  mintType: 'EditionMax'
+}
+
+export type MintConfig = MerkleDropConfig | RangeEditionConfig | EditionMaxMinterConfig
 
 export function isMerkleDropConfig(config: MintConfig): config is MerkleDropConfig {
   return config.mintType === 'MerkleDrop'
@@ -176,6 +192,10 @@ export function isMerkleDropConfig(config: MintConfig): config is MerkleDropConf
 
 export function isRangeEditionConfig(config: MintConfig): config is RangeEditionConfig {
   return config.mintType === 'RangeEdition'
+}
+
+export function isExitionMaxMinterConfig(config: MintConfig): config is EditionMaxMinterConfig {
+  return config.mintType === 'EditionMax'
 }
 
 export type ContractCall = {

--- a/packages/sdk/src/utils/constants.ts
+++ b/packages/sdk/src/utils/constants.ts
@@ -4,16 +4,19 @@ import {
   MerkleDropMinter__factory,
   SoundEditionV1_1__factory,
   IMinterModule__factory,
+  EditionMaxMinter__factory,
 } from '@soundxyz/sound-protocol/typechain/index'
 
 const editionInterface = SoundEditionV1_1__factory.createInterface()
 const iMinterModuleInterface = IMinterModule__factory.createInterface()
 const rangeMinterInterface = RangeEditionMinter__factory.createInterface()
 const merkleMinterInteface = MerkleDropMinter__factory.createInterface()
+const editionMaxMinterInterface = EditionMaxMinter__factory.createInterface()
 
 export const minterFactoryMap = {
   [interfaceIds.IRangeEditionMinter]: RangeEditionMinter__factory,
   [interfaceIds.IMerkleDropMinter]: MerkleDropMinter__factory,
+  [interfaceIds.IEditionMaxMinter]: EditionMaxMinter__factory,
 } as const
 
 // This is hardcoded on the contract so we always know its 2
@@ -134,6 +137,9 @@ export const ContractErrorSigHashToName = {
   [merkleMinterInteface.getSighash(ExceedsMaxPerAccount)]: ExceedsMaxPerAccount,
   [merkleMinterInteface.getSighash(MerkleRootHashIsEmpty)]: MerkleRootHashIsEmpty,
   [merkleMinterInteface.getSighash(MaxMintablePerAccountIsZero)]: MaxMintablePerAccountIsZero,
+  // EditionMaxMinter
+  [editionMaxMinterInterface.getSighash(ExceedsMaxPerAccount)]: ExceedsMaxPerAccount,
+  [editionMaxMinterInterface.getSighash(MaxMintablePerAccountIsZero)]: MaxMintablePerAccountIsZero,
 } as const
 
 export type ContractErrorSigHashToName = typeof ContractErrorSigHashToName[keyof typeof ContractErrorSigHashToName]

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -443,7 +443,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
     expect(editionInfo.editionMaxMintable).to.equal(EDITION_MAX)
   })
 
-  it(`Eligible quantity becomes zero for every user if range edition mint instance is sold out before cutoffTime`, async () => {
+  it(`Eligible quantity becomes zero for every user if range edition mint schedule is sold out before cutoffTime`, async () => {
     const maxMintableUpper = 8
     const startTime = now()
     const MINT_ID = 0
@@ -557,7 +557,9 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
       expect(eligibleQuantity).to.equal(0)
     }
   })
+})
 
+describe('eligibleQuantity: multiple sale schedules', () => {
   it(`Eligible quantity changes if querying between multiple mints with different start times and max mintable quantities.`, async () => {
     const mint1StartTime = now()
     const mint1EndTime = mint1StartTime + ONE_HOUR

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -690,7 +690,7 @@ describe('eligibleQuantity: multiple sale schedules', () => {
         ]),
       },
       {
-        contractAddress: editionMaxMinter.address,
+        contractAddress: rangeEditionMinter.address,
         calldata: rangeMinter.interface.encodeFunctionData('createEditionMint', [
           precomputedEditionAddress,
           PRICE,
@@ -1125,7 +1125,7 @@ describe('BaseMinter functionality', () => {
           startTime,
           startTime + ONE_HOUR,
           0, // affiliateFeeBPS
-          2, // maxMintablePerAccount,
+          EDITION_MAX, // maxMintablePerAccount,
         ]),
       },
     ]
@@ -1179,7 +1179,7 @@ describe('BaseMinter functionality', () => {
   })
 
   it(`Should throw error if more than eligibleQuantity requested`, async () => {
-    const quantity = 5
+    const quantity = EDITION_MAX + 1
     const eligibleQuantity = await client.eligibleQuantity({
       mintSchedule: mintSchedules[0],
       userAddress: buyerWallet.address,
@@ -1187,11 +1187,9 @@ describe('BaseMinter functionality', () => {
     await client
       .mint({ mintSchedule: mintSchedules[0], quantity })
       .then(didntThrowExpectedError)
-      .catch((error) => {
+      .catch(async (error) => {
         expect(error).instanceOf(NotEligibleMint)
-
         assert(error instanceof NotEligibleMint)
-
         expect(error.eligibleMintQuantity).equal(eligibleQuantity)
       })
   })
@@ -1834,6 +1832,7 @@ describe('editionScheduleIds', () => {
     expect(scheduleIds).deep.eq([
       { minterAddress: merkleDropMinter.address, mintIds: [0] },
       { minterAddress: rangeEditionMinter.address, mintIds: [0] },
+      { minterAddress: editionMaxMinter.address, mintIds: [] },
     ])
   })
 })

--- a/packages/sdk/test/test-constants.ts
+++ b/packages/sdk/test/test-constants.ts
@@ -4,5 +4,9 @@ export const DEFAULT_SALT = getSaltAsBytes32(12345678)
 export const SOUND_FEE = 0
 export const ONE_HOUR = 3600
 export const PRICE = 420420420
+<<<<<<< HEAD
 export const BAD_ADDRESS = 'not an address'
 export const EDITION_MAX = 100
+=======
+export const EDITION_MAX = 50
+>>>>>>> changeset

--- a/packages/sdk/test/test-constants.ts
+++ b/packages/sdk/test/test-constants.ts
@@ -4,9 +4,5 @@ export const DEFAULT_SALT = getSaltAsBytes32(12345678)
 export const SOUND_FEE = 0
 export const ONE_HOUR = 3600
 export const PRICE = 420420420
-<<<<<<< HEAD
 export const BAD_ADDRESS = 'not an address'
 export const EDITION_MAX = 100
-=======
-export const EDITION_MAX = 50
->>>>>>> changeset


### PR DESCRIPTION

EditionMaxMinter is a cheaper alternative to RangeEditionMinter and should be used whenever an artist plans to only have a single public sale for an edition.


![image](https://user-images.githubusercontent.com/32403632/209236158-33544af3-dec5-4b38-9cf7-275d29cac20c.png)
![image](https://user-images.githubusercontent.com/32403632/209236179-aa805850-e65b-4c34-b0d7-d122e7caede4.png)

