### PR TITLE
Makes eligibleQuantity respect edition over mint schedule quantity

### DIFF
--- a/.changeset/eighty-cows-thank.md
+++ b/.changeset/eighty-cows-thank.md
@@ -2,4 +2,4 @@
 '@soundxyz/sdk': patch
 ---
 
-Makes eligibleQuantity prioritize edition quantity over mint schedule quantity
+Makes eligibleQuantity respect edition quantity over mint schedule quantity

--- a/.changeset/eighty-cows-thank.md
+++ b/.changeset/eighty-cows-thank.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/sdk': patch
+---
+
+Makes eligibleQuantity prioritize edition quantity over mint schedule quantity

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -240,9 +240,13 @@ export function SoundClient({
     // Get the edition's remaining token quantity.
     const { signerOrProvider } = await _requireSignerOrProvider()
     const editionContract = SoundEditionV1_1__factory.connect(mintSchedule.editionAddress, signerOrProvider)
-    const editionTotalMinted = (await editionContract.totalMinted()).toNumber()
-    const editionMaxMintable = await editionContract.editionMaxMintable()
-    const editionRemainingQty = editionMaxMintable - editionTotalMinted
+
+    const [editionTotalMinted, editionMaxMintable] = await Promise.all([
+      editionContract.totalMinted(),
+      editionContract.editionMaxMintable(),
+    ])
+
+    const editionRemainingQty = editionMaxMintable - editionTotalMinted.toNumber()
 
     if (!editionRemainingQty) {
       return 0

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -264,7 +264,7 @@ export function SoundClient({
 
     // Return the minimum of the two. The number of tokens minted within the mint schedule
     // can never exceed the number of tokens available for the edition.
-    return Math.min(scheduleEligibleQty, editionRemainingQty)
+    return Math.max(0, Math.min(scheduleEligibleQty, editionRemainingQty))
   }
 
   function getMerkleProof({ merkleRoot, userAddress }: MerkleProofParameters) {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -250,8 +250,8 @@ export function SoundClient({
         ? mintSchedule.maxMintable(timestamp)
         : mintSchedule.maxMintable) - mintSchedule.totalMinted
 
-    const alreadyMintedByUser = await numberMinted({ editionAddress: mintSchedule.editionAddress, userAddress })
-    const eligibleForUserOnSchedule = mintSchedule.maxMintablePerAccount - alreadyMintedByUser
+    const mintedByUserFromSchedule = await numberMinted({ editionAddress: mintSchedule.editionAddress, userAddress })
+    const eligibleForUserOnSchedule = mintSchedule.maxMintablePerAccount - mintedByUserFromSchedule
     const scheduleEligibleQty = Math.min(remainingForSchedule, eligibleForUserOnSchedule)
 
     // Return the minimum of the two. The number of tokens minted within the mint schedule

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -237,14 +237,14 @@ export function SoundClient({
       }
     }
 
-    // Get eligible quantity for the edition
+    // Get the edition's remaining token quantity.
     const { signerOrProvider } = await _requireSignerOrProvider()
     const editionContract = SoundEditionV1_1__factory.connect(mintSchedule.editionAddress, signerOrProvider)
     const editionTotalMinted = (await editionContract.totalMinted()).toNumber()
     const editionMaxMintable = await editionContract.editionMaxMintable()
-    const editionEligibleQuantity = editionMaxMintable - editionTotalMinted
+    const editionRemainingQty = editionMaxMintable - editionTotalMinted
 
-    // Get eligible quantity for the mint schedule
+    // Get eligible quantity for the user on this mint schedule.
     const remainingForSchedule =
       (typeof mintSchedule.maxMintable === 'function'
         ? mintSchedule.maxMintable(timestamp)
@@ -252,11 +252,11 @@ export function SoundClient({
 
     const alreadyMintedByUser = await numberMinted({ editionAddress: mintSchedule.editionAddress, userAddress })
     const eligibleForUserOnSchedule = mintSchedule.maxMintablePerAccount - alreadyMintedByUser
-    const scheduleEligibleQuantity = Math.min(remainingForSchedule, eligibleForUserOnSchedule)
+    const scheduleEligibleQty = Math.min(remainingForSchedule, eligibleForUserOnSchedule)
 
-    // Return the minimum of the two, because the number of tokens minted within the mint schedule
+    // Return the minimum of the two. The number of tokens minted within the mint schedule
     // can never exceed the number of tokens available for the edition.
-    return Math.min(scheduleEligibleQuantity, editionEligibleQuantity)
+    return Math.min(scheduleEligibleQty, editionRemainingQty)
   }
 
   function getMerkleProof({ merkleRoot, userAddress }: MerkleProofParameters) {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -244,6 +244,10 @@ export function SoundClient({
     const editionMaxMintable = await editionContract.editionMaxMintable()
     const editionRemainingQty = editionMaxMintable - editionTotalMinted
 
+    if (!editionRemainingQty) {
+      return 0
+    }
+
     // Get eligible quantity for the user on this mint schedule.
     const remainingForSchedule =
       (typeof mintSchedule.maxMintable === 'function'

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -237,12 +237,14 @@ export function SoundClient({
       }
     }
 
+    // Get eligible quantity for the edition
     const { signerOrProvider } = await _requireSignerOrProvider()
     const editionContract = SoundEditionV1_1__factory.connect(mintSchedule.editionAddress, signerOrProvider)
     const editionTotalMinted = (await editionContract.totalMinted()).toNumber()
     const editionMaxMintable = await editionContract.editionMaxMintable()
     const editionEligibleQuantity = editionMaxMintable - editionTotalMinted
 
+    // Get eligible quantity for the mint schedule
     const remainingForSchedule =
       (typeof mintSchedule.maxMintable === 'function'
         ? mintSchedule.maxMintable(timestamp)
@@ -252,6 +254,8 @@ export function SoundClient({
     const eligibleForUserOnSchedule = mintSchedule.maxMintablePerAccount - alreadyMintedByUser
     const scheduleEligibleQuantity = Math.min(remainingForSchedule, eligibleForUserOnSchedule)
 
+    // Return the minimum of the two, because the number of tokens minted within the mint schedule
+    // can never exceed the number of tokens available for the edition.
     return Math.min(scheduleEligibleQuantity, editionEligibleQuantity)
   }
 

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -637,7 +637,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
     )
   })
 
-  it('eligibleQuantity respects the available quantity on the edition over the eligible amount on mint schedules', async () => {
+  it('eligibleQuantity respects the available quantity on the edition over the eligible quantity on mint schedules', async () => {
     const client = SoundClient({
       provider: ethers.provider,
       signer: buyerWallet,
@@ -692,7 +692,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
 
     await setupTest({ minterCalls })
 
-    let mintSchedules = await client.activeMintSchedules({ editionAddress: precomputedEditionAddress })
+    const mintSchedules = await client.activeMintSchedules({ editionAddress: precomputedEditionAddress })
 
     expect(mintSchedules.length).to.equal(2)
 
@@ -701,8 +701,6 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
       mintSchedule: mintSchedules[0],
       quantity: EDITION_MAX,
     })
-
-    mintSchedules = await client.activeMintSchedules({ editionAddress: precomputedEditionAddress })
 
     // Check that the eligible quantity for the next mint schedule is zero for both buyers
     const eligibleQuantityBuyer1 = await client.eligibleQuantity({

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -28,7 +28,7 @@ import {
   InvalidMaxMintablePerAccountError,
   InvalidMaxMintableError,
 } from '../src/errors'
-import { DEFAULT_SALT, SOUND_FEE, ONE_HOUR, PRICE, BAD_ADDRESS } from './test-constants'
+import { DEFAULT_SALT, SOUND_FEE, ONE_HOUR, PRICE, BAD_ADDRESS, EDITION_MAX } from './test-constants'
 import {
   MINTER_ROLE,
   NULL_ADDRESS,
@@ -131,8 +131,8 @@ export async function setupTest({ minterCalls = [] }: { minterCalls?: ContractCa
     'https://contractURI.com',
     NON_NULL_ADDRESS,
     0, //royaltyBPS,
-    100, // maxMintableLower
-    100, // maxMintableUpper
+    EDITION_MAX, // maxMintableLower
+    EDITION_MAX, // maxMintableUpper
     UINT32_MAX, // cutoffTime
     2,
   ])
@@ -374,7 +374,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
 
     expect(editionInfo.totalMinted).to.equal(1)
 
-    expect(editionInfo.editionMaxMintable).to.equal(100)
+    expect(editionInfo.editionMaxMintable).to.equal(EDITION_MAX)
   })
 
   it(`Eligible quantity is zero outside of minting time`, async () => {
@@ -431,7 +431,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
 
     expect(editionInfo.totalMinted).to.equal(0)
 
-    expect(editionInfo.editionMaxMintable).to.equal(100)
+    expect(editionInfo.editionMaxMintable).to.equal(EDITION_MAX)
   })
 
   it(`Eligible quantity becomes zero for every user if range edition mint instance is sold out before cutoffTime`, async () => {
@@ -635,6 +635,88 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
       (typeof mintSchedule.maxMintable === 'function' ? mintSchedule.maxMintable() : mintSchedule.maxMintable) -
         mint1MaxMintablePerAccount,
     )
+  })
+
+  it('eligible quantity is always zero if the edition is sold out, regardless of mint schedule eligible quantity', async () => {
+    const client = SoundClient({
+      provider: ethers.provider,
+      signer: buyerWallet,
+      merkleProvider: {
+        merkleProof({ userAddress }) {
+          return merkleTestHelper.getProof({ merkleTree, address: userAddress })
+        },
+      },
+    })
+
+    const merkleTestHelper = MerkleTestHelper()
+    const startTimeForBoth = now()
+    const endTimeForBoth = UINT32_MAX
+    const maxMintable = EDITION_MAX
+    const maxMintablePerAccount = EDITION_MAX
+
+    const merkleMinter = MerkleDropMinter__factory.connect(merkleDropMinter.address, artistWallet)
+    const rangeMinter = RangeEditionMinter__factory.connect(rangeEditionMinter.address, artistWallet)
+
+    const merkleTree = merkleTestHelper.getMerkleTree()
+    const merkleRoot = merkleTestHelper.getMerkleRoot(merkleTree)
+
+    const minterCalls = [
+      {
+        contractAddress: merkleDropMinter.address,
+        calldata: merkleMinter.interface.encodeFunctionData('createEditionMint', [
+          precomputedEditionAddress,
+          merkleRoot,
+          PRICE,
+          startTimeForBoth,
+          endTimeForBoth,
+          0, // affiliateFeeBPS
+          maxMintable,
+          maxMintablePerAccount,
+        ]),
+      },
+      {
+        contractAddress: rangeEditionMinter.address,
+        calldata: rangeMinter.interface.encodeFunctionData('createEditionMint', [
+          precomputedEditionAddress,
+          PRICE,
+          startTimeForBoth,
+          startTimeForBoth + ONE_HOUR, // cutoffTime,
+          startTimeForBoth + ONE_HOUR + 1, // endTime
+          0, // affiliateFeeBPS
+          maxMintable - 1, // maxMintableLower,
+          maxMintable, // maxMintableUpper,
+          maxMintablePerAccount,
+        ]),
+      },
+    ]
+
+    await setupTest({ minterCalls })
+
+    let mintSchedules = await client.activeMintSchedules({ editionAddress: precomputedEditionAddress })
+
+    expect(mintSchedules.length).to.equal(2)
+
+    // Mint entire supply from first mint schedule
+    await client.mint({
+      mintSchedule: mintSchedules[0],
+      quantity: EDITION_MAX,
+    })
+
+    mintSchedules = await client.activeMintSchedules({ editionAddress: precomputedEditionAddress })
+
+    // Check that the eligible quantity for the next mint schedule is zero for both buyers
+    const eligibleQuantityBuyer1 = await client.eligibleQuantity({
+      mintSchedule: mintSchedules[1],
+      userAddress: buyerWallet.address,
+    })
+
+    const eligibleQuantityBuyer2 = await client.eligibleQuantity({
+      mintSchedule: mintSchedules[1],
+      userAddress: buyer2Wallet.address,
+    })
+
+    expect(eligibleQuantityBuyer1).to.equal(0)
+    expect(eligibleQuantityBuyer2).to.equal(0)
   })
 })
 

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -637,7 +637,7 @@ describe('eligibleQuantity: single RangeEditionMinter instance', () => {
     )
   })
 
-  it('eligible quantity is always zero if the edition is sold out, regardless of mint schedule eligible quantity', async () => {
+  it('eligibleQuantity respects the available quantity on the edition over the eligible amount on mint schedules', async () => {
     const client = SoundClient({
       provider: ethers.provider,
       signer: buyerWallet,

--- a/packages/sdk/test/test-constants.ts
+++ b/packages/sdk/test/test-constants.ts
@@ -5,3 +5,4 @@ export const SOUND_FEE = 0
 export const ONE_HOUR = 3600
 export const PRICE = 420420420
 export const BAD_ADDRESS = 'not an address'
+export const EDITION_MAX = 100


### PR DESCRIPTION
Noticed this issue with `eligibleQuantity` [while adding EditionMaxMinter]([url](https://github.com/soundxyz/sdk/pull/167)).

There is no on-chain validation enforcing that editions are initialized with enough tokens to accommodate the quantities on all of their mint schedules, but `eligibleQuantity` is currently only looking at the mint schedule. 

We need to check what is available on the edition because when `editionMaxMintable` has been reached, all subsequent mints will fail regardless if a user still has an eligible quantity for a mint schedule. 