### PR TITLE
Fixes deprecated syntax in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=date::$(date +"%B %d, %Y")"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(date +"%B %d, %Y")" >> $GITHUB_OUTPUT
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
We're getting a warning about this syntax being deprecated. Don't think we can test it until its merged to `main` (I tried). 

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/