### PR TITLE
Use getLogs directly instead of creating a filter and querying it

### DIFF
--- a/.changeset/great-dragons-cough.md
+++ b/.changeset/great-dragons-cough.md
@@ -1,0 +1,6 @@
+---
+'@soundxyz/legacy-sdk': minor
+'@soundxyz/sdk': minor
+---
+
+legacy sdk minter performance issue fix

--- a/packages/legacy-sdk/src/types.ts
+++ b/packages/legacy-sdk/src/types.ts
@@ -18,7 +18,7 @@ type LazyOption<T extends object> = T | (() => T | Promise<T>)
 
 export type ClientProvider = Pick<
   PublicClient,
-  'chain' | 'readContract' | 'getFilterLogs' | 'createEventFilter' | 'estimateContractGas' | 'multicall'
+  'chain' | 'readContract' | 'getLogs' | 'estimateContractGas' | 'multicall'
 >
 export type Wallet = Pick<WalletClient, 'account' | 'chain' | 'writeContract' | 'signMessage' | 'sendTransaction'>
 

--- a/packages/sdk/src/contract/edition-v1/read/actions.ts
+++ b/packages/sdk/src/contract/edition-v1/read/actions.ts
@@ -21,10 +21,7 @@ import { editionMintSchedules, editionMintSchedulesFromIds, editionScheduleIds }
 import type { MerkleProvider } from '../../../utils/types'
 
 export function editionV1PublicActions<
-  Client extends Pick<
-    PublicClient,
-    'readContract' | 'multicall' | 'estimateContractGas' | 'createEventFilter' | 'getFilterLogs'
-  > & {
+  Client extends Pick<PublicClient, 'readContract' | 'multicall' | 'estimateContractGas' | 'getLogs'> & {
     editionV1?: {
       sam?: {}
     }


### PR DESCRIPTION
Looks like an unintended change introduced in the ether to viem port for legacy sdk,
Creating an event filter on the node, and then querying it as 2 steps is unnecessary and has perf issues

Instead of`createEventFilter` and `getFilterLogs`, 
we can use `getLogs` and pass the event filters with the call, and get typesafe results

